### PR TITLE
Recommended addition to docs.

### DIFF
--- a/sections/failing_service.html
+++ b/sections/failing_service.html
@@ -3,7 +3,7 @@
 <p>BOSH is using <a href="https://mmonit.com/monit/">monit</a> to monitor running services. If the service goes down it will bring it up. Let's watch how this works. SSH to one of VMs (provide any temporary password when prompted, same password will be used for sudo):</p>
 
 <div class="terminal-block">
-  <h4 class="terminal-code-text">$ bosh ssh app/0</h4>
+  <h4 class="terminal-code-text">$ bosh ssh app/0 --strict_host_key_checking no</h4>
   <h4 class="terminal-code-text">$ sudo su</h4>
   <h4 class="terminal-code-text">$ while monit summary; do sleep 1; done</h4>
   <h4 class="terminal-printout-text">The Monit daemon 5.2.4 uptime: 10m


### PR DESCRIPTION
Ran into the issue of being unable to `bosh ssh` per the original docs. It appears that a bosh update has occurred since the documentation per Dr. Nic's issue below.

Updated docs to include strict host key issue noted in https://github.com/cloudfoundry/bosh-lite/issues/288
