### PR TITLE
Add director_uuid update note

### DIFF
--- a/sections/set_manifest.html
+++ b/sections/set_manifest.html
@@ -1,6 +1,14 @@
 <%= circled_title(2, "Set Deployment Manifest") %>
 
-<p>Deployment manifest specifies what services to deploy, their properties and resources configuration. Set the deployment manifest:</p>
+<p>Deployment manifest specifies what services to deploy, their properties and resources configuration. The manifest contains a placeholder <b>director_uuid</b> that needs replacing.</p>
+
+<p>Update the <b>director_uuid</b> value in the <b>manifest.yml</b> with the value from:</p>
+
+<div class='terminal-block'>
+  <h4 class="terminal-code-text">$ bosh status</h4>
+</div>
+
+<p>Set the deployment manifest:</p>
 
 <div class="terminal-block">
   <h4 class="terminal-code-text">$ bosh deployment manifest.yml</h4>


### PR DESCRIPTION
When following the tutorial, the 'Set Deployment Manifest' step fails if
the `director_uuid` is not updated with the value from `$ bosh status`.

This PR just adds a note to update this value, and where to get the new
value from.
