### PR TITLE
Simplify how the director UUID is retrieved

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@ Releases total: 1
 <p>Update the <b>director_uuid</b> value in the <b>manifest.yml</b> with the value from:</p>
 
 <div class='terminal-block'>
-  <h4 class="terminal-code-text">$ bosh status</h4>
+  <h4 class="terminal-code-text">$ bosh status --uuid</h4>
 </div>
 
 <p>Set the deployment manifest:</p>


### PR DESCRIPTION
bosh_cli can display the director UUID alone with `bosh status --uuid`.
