### PR TITLE
Adding the route requires a different command on Linux

### DIFF
--- a/sections/run_deploy.html
+++ b/sections/run_deploy.html
@@ -20,7 +20,12 @@
 <p>Add route to bosh-lite network:</p>
 <div class="terminal-block">
   <h4 class="terminal-code-text">$ sudo route add -net 10.244.0.0/19 192.168.50.4</h4>
-</div> 
+</div>
+
+<p>If your workstation runs Linux, use this command instead:</p>
+<div class="terminal-block">
+  <h4 class="terminal-code-text">$ sudo ip route add 10.244.0.0/19 via 192.168.50.4</h4>
+</div>
 
 <p>See that our service is up and running.</p>
 


### PR DESCRIPTION
This commit corrects [f3c183d](https://github.com/suhlig/learn-bosh/commit/f3c183dca70418c1803005a3d4e39ebc24abaac1) by making the change in the source file and not in the (generated) index.html.
