### PR TITLE
Load jQuery from Google CDN using https. Javascript on page won't work if loaded using https.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 
   <script type="text/javascript" src="fullpage_js/vendors/jquery.slimscroll.min.js"></script>
   <script type="text/javascript" src="fullpage_js/jquery.fullPage.min.js"></script>

--- a/templates/index.html.erb
+++ b/templates/index.html.erb
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 
   <script type="text/javascript" src="fullpage_js/vendors/jquery.slimscroll.min.js"></script>
   <script type="text/javascript" src="fullpage_js/jquery.fullPage.min.js"></script>


### PR DESCRIPTION
Reference:
https://developer.mozilla.org/en-US/docs/Security/Mixed_content/How_to_fix_website_with_mixed_content
