### PR TITLE
Added reference to BOSH VM configuration

### DIFF
--- a/sections/failing_vm.html
+++ b/sections/failing_vm.html
@@ -45,4 +45,5 @@
 <ul>
 <li><a href="http://bosh.io/docs/resurrector.html">bosh.io: Automatic repair with Resurrector</a></li>
 <li><a href="http://bosh.io/docs/cck.html">bosh.io: Manual repair with Cloud Check</a></li>
+<li><a href="http://bosh.io/docs/vm-config.html">bosh.io: Configuration and file locations of BOSH VMs</a></li>
 </p>


### PR DESCRIPTION
For debugging a failing deploy, a link to the documentation concerning VM configuration should be very helpful. All the locations of the files inside the directory is described here and will help new BOSH developers to find information about what went wrong.

Maybe you find a better place for this link but I think it should be part of the tutorial.
