### PR TITLE
Add credhub by default

### DIFF
--- a/sections/setup_bosh_environment.html
+++ b/sections/setup_bosh_environment.html
@@ -16,6 +16,8 @@
   -o bosh-deployment/bosh-lite.yml \<br>
   -o bosh-deployment/bosh-lite-runc.yml \<br>
   -o bosh-deployment/jumpbox-user.yml \<br>
+  -o bosh-deployment/uaa.yml \<br>
+  -o bosh-deployment/credhub.yml \<br>
   --vars-store vbox/creds.yml \<br>
   -v director_name="Bosh Lite Director" \<br>
   -v internal_ip=192.168.50.6 \<br>

--- a/sections/setup_bosh_environment.html
+++ b/sections/setup_bosh_environment.html
@@ -19,7 +19,7 @@
   -o bosh-deployment/uaa.yml \<br>
   -o bosh-deployment/credhub.yml \<br>
   --vars-store vbox/creds.yml \<br>
-  -v director_name="Bosh Lite Director" \<br>
+  -v director_name="Bosh-Lite-Director" \<br>
   -v internal_ip=192.168.50.6 \<br>
   -v internal_gw=192.168.50.1 \<br>
   -v internal_cidr=192.168.50.0/24 \<br>


### PR DESCRIPTION
For anyone who'll use the `bosh create-env` instructions to maintain + play with their bosh-lite, it'd be great that the instructions they copy/paste include credhub/config-server.

As an example, @cppforlife's service broker assumes there is a config-server https://github.com/cppforlife/bosh-generic-sb-release/issues/9