### PR TITLE
Updated Documentation URLs

### DIFF
--- a/sections/introduction.html
+++ b/sections/introduction.html
@@ -5,7 +5,7 @@
 
 <p>Learn more: 
 <ul>
-<li><a href="http://bosh.io/docs/about.html">bosh.io: What is BOSH?</a></li>
+<li><a href="http://bosh.io/docs/">bosh.io: What is BOSH?</a></li>
 <li><a href="http://bosh.io/docs/problems.html">bosh.io: What Problems Does BOSH Solve?</a></li>
 </p>
 

--- a/sections/setup_bosh_environment.html
+++ b/sections/setup_bosh_environment.html
@@ -24,7 +24,7 @@
   -v outbound_network_name=NatNetwork</h4>
 </div>
 
-<p>In case of any issues see <a href="https://github.com/cloudfoundry/bosh-deployment/blob/master/docs/bosh-lite-on-vbox.md">bosh-deployment VirtualBox docs</a>.</p>
+<p>In case of any issues see <a href="https://bosh.io/docs/bosh-lite/">bosh-deployment VirtualBox docs</a>.</p>
 
 <p>Learn more:
 <ul>


### PR DESCRIPTION
The URL for About results in a 404. It appears the About URL is now available at the root of the folder without a filename specified.